### PR TITLE
feat: add mythic britain & ireland archetypes and talent

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -347,6 +347,51 @@ const ARCHETYPES_LIST: ArchetypeDefinition[] = [
         ],
         description: "Observes and chronicles the world, often drawn to unusual stories and the depths of human (and inhuman) nature."
     },
+    { 
+        name: "Athlete", mainAttribute: "Physique", mainSkill: "One Physique skill, depending on chosen sport", 
+        talentChoices: ["Famous", "Robust", "Sprinter", "Pugilist", "Gentleman", "Combat-Trained", "Fleet-footed", "Defensive", "Combat-Trained"], 
+        resourceRange: [2, 4], 
+        startingEquipment: ["Athletic apparel", "Equipment for sport of choice"],
+        motivations: ["Increase one’s own abilities", "Avenge a past defeat", "Find out who is natural and who is not"],
+        traumas: ["Lost a fairy bet", "Cursed by a game-fixing witch", "Searching for a missing team-mate"],
+        darkSecrets: ["Drug addicted", "Cheats", "Will fix games for money"],
+        relationshipHooks: [
+            "Good enough company",
+            "A potential rival",
+            "Doesn't like sport, therefore uninteresting"
+        ],
+        description: "A character who excels in physical activities and sports, often driven by competition and personal achievement."
+    },
+    { 
+        name: "Entertainer", mainAttribute: "Empathy", mainSkill: "Manipulation", 
+        talentChoices: ["Famous", "Performer", "Well-Traveled"], 
+        resourceRange: [2, 4], 
+        startingEquipment: ["Costumes", "Make-up", "Scripts"],
+        motivations: ["Find out the truth behind superstitions", "Cleanse a favorite theatre", "Make sure the show can always go on"],
+        traumas: ["Injured by angry spirit", "Saw friends killed by supernatural beings", "Searching for an abducted friend or relative"],
+        darkSecrets: ["Alcoholic", "On the run", "Made a devil’s bargain for success"],
+        relationshipHooks: [
+            "A complete bore",
+            "A potential lover",
+            "I feel you judging me"
+        ],
+        description: "A performer who thrives on attention and admiration, using charm and wit to navigate social situations and captivate audiences."
+    },
+    { 
+        name: "Socialite", mainAttribute: "Empathy", mainSkill: "Inspiration", 
+        talentChoices: ["Famous", "Gentleman", "Wealthy"], 
+        resourceRange: [4, 7], 
+        startingEquipment: ["London apartment", "Country estate", "Revolver"],
+        motivations: ["Removing threats to estate and tenants", "Collecting stories to tell", "Proving one’s quality"],
+        traumas: ["Attacked by castle ghost", "Tenants or relatives abducted by fairies", "Driven from ancestral home by redcaps"],
+        darkSecrets: ["Born from an affair", "Secretly impoverished", "Accidentally killed someone"],
+        relationshipHooks: [
+            "An amusing companion",
+            "Useful, but not a suitable friend",
+            "A good friend"
+        ],
+        description: "A well-connected individual who moves in high society, leveraging influence and resources to address supernatural challenges."
+    },
     {
         name: "Custom Life Path", mainAttribute: "", mainSkill: "",
         talentChoices: [], 
@@ -468,6 +513,7 @@ const ALL_TALENTS_LIST: TalentDefinition[] = [
     { id: "sprinter", name: "Sprinter", description: "Gain +2 to AGILITY when trying to outrun or chase down someone." },
     { id: "theLordsShepherd", name: "The Lord's Shepherd", description: "Gain +2 when using INSPIRATION to treat a mental critical injury." },
     { id: "wealthy", name: "Wealthy", description: "Increase Resources by 1 (can be purchased multiple times)." },
+    { id: "performer", name: "Performer", description: "Ignore Conditions when making INSPIRATION or MANIPULATION tests." },
 ];
 
 const ARMOR_DEFINITIONS: ArmorDefinition[] = [

--- a/index.tsx
+++ b/index.tsx
@@ -1883,7 +1883,7 @@ function loadCharacterFromLocalStorage(): Character | null {
 // --- TALENT HELPERS ---
 function canTakeTalentMultipleTimes(talentId: string): boolean {
     // List of talents that can be taken multiple times
-    const multipleTimeTalents = ['tactician', 'wealthy'];
+    const multipleTimeTalents = ['wealthy'];
     return multipleTimeTalents.includes(talentId);
 }
 

--- a/index.tsx
+++ b/index.tsx
@@ -349,7 +349,7 @@ const ARCHETYPES_LIST: ArchetypeDefinition[] = [
     },
     { 
         name: "Athlete", mainAttribute: "Physique", mainSkill: "One Physique skill, depending on chosen sport", 
-        talentChoices: ["Famous", "Robust", "Sprinter", "Pugilist", "Gentleman", "Combat-Trained", "Fleet-footed", "Defensive", "Combat-Trained"], 
+        talentChoices: ["Famous", "Robust", "Sprinter", "Pugilist", "Gentleman", "Combat-Trained", "Fleet-footed", "Defensive"], 
         resourceRange: [2, 4], 
         startingEquipment: ["Athletic apparel", "Equipment for sport of choice"],
         motivations: ["Increase one’s own abilities", "Avenge a past defeat", "Find out who is natural and who is not"],
@@ -1880,6 +1880,13 @@ function loadCharacterFromLocalStorage(): Character | null {
 }
 
 
+// --- TALENT HELPERS ---
+function canTakeTalentMultipleTimes(talentId: string): boolean {
+    // List of talents that can be taken multiple times
+    const multipleTimeTalents = ['tactician', 'wealthy'];
+    return multipleTimeTalents.includes(talentId);
+}
+
 // --- MODAL HANDLING ---
 const relationshipModal = getEl<HTMLDivElement>('addRelationshipModal');
 const relationshipModalTitle = getEl<HTMLHeadingElement>('relationshipModalTitle');
@@ -2864,7 +2871,43 @@ function setupEventListeners() {
         openTalentModalBtn.addEventListener('click', () => {
             addTalentModal.style.display = 'block'; modalTalentSelect.innerHTML = '<option value="" title="">-- Select a Talent --</option>';
             const existingArchetypeTalentId = character.talents.find(tId => ALL_TALENTS_LIST.find(t => t.id === tId)?.archetype === character.archetype);
-            ALL_TALENTS_LIST.filter(t => !t.archetype && !character.talents.includes(t.id) && t.id !== existingArchetypeTalentId).forEach(t => { const o=document.createElement('option');o.value=t.id;o.textContent=t.name;o.title=t.description;modalTalentSelect.appendChild(o); });
+            
+            // Create categorized options: General talents first, then Archetype talents grouped by archetype
+            const generalTalents = ALL_TALENTS_LIST.filter(t => !t.archetype && (!character.talents.includes(t.id) || canTakeTalentMultipleTimes(t.id)));
+            const archetypeTalents = ALL_TALENTS_LIST.filter(t => t.archetype && (!character.talents.includes(t.id) || canTakeTalentMultipleTimes(t.id)) && t.id !== existingArchetypeTalentId);
+            
+            // Add general talents
+            if (generalTalents.length > 0) {
+                const generalGroup = document.createElement('optgroup');
+                generalGroup.label = 'General Talents';
+                generalTalents.forEach(t => {
+                    const o = document.createElement('option');
+                    o.value = t.id; o.textContent = t.name; o.title = t.description;
+                    if (character.talents.includes(t.id)) o.textContent += ' (can take multiple times)';
+                    generalGroup.appendChild(o);
+                });
+                modalTalentSelect.appendChild(generalGroup);
+            }
+            
+            // Add archetype talents grouped by archetype
+            const archetypeGroups = {};
+            archetypeTalents.forEach(t => {
+                if (!archetypeGroups[t.archetype]) archetypeGroups[t.archetype] = [];
+                archetypeGroups[t.archetype].push(t);
+            });
+            
+            Object.keys(archetypeGroups).sort().forEach(archetypeName => {
+                const group = document.createElement('optgroup');
+                group.label = `${archetypeName} Talents`;
+                archetypeGroups[archetypeName].forEach(t => {
+                    const o = document.createElement('option');
+                    o.value = t.id; o.textContent = t.name; o.title = t.description;
+                    if (character.talents.includes(t.id)) o.textContent += ' (can take multiple times)';
+                    group.appendChild(o);
+                });
+                modalTalentSelect.appendChild(group);
+            });
+            
             modalTalentDesc.textContent = 'Description will appear here.'; updateSelectTooltip(modalTalentSelect); 
         });
     }
@@ -2873,11 +2916,13 @@ function setupEventListeners() {
     if (confirmAddTalentBtn && modalTalentSelect && addTalentModal) {
         confirmAddTalentBtn.addEventListener('click', () => { 
             const tId=modalTalentSelect.value; 
-            if(tId && !character.talents.includes(tId)){
+            if(tId){
                 character.talents.push(tId);
                 renderTalents(); 
                 saveCharacterToLocalStorage();
-                console.log(`Talent "${ALL_TALENTS_LIST.find(t=>t.id === tId)?.name}" added.`);
+                const talentName = ALL_TALENTS_LIST.find(t=>t.id === tId)?.name;
+                const count = character.talents.filter(id => id === tId).length;
+                console.log(`Talent "${talentName}" added${count > 1 ? ` (now have ${count})` : ''}.`);
             } 
             closeModal(addTalentModal); 
         });


### PR DESCRIPTION
This PR expands the available character archetypes and talents from the _Vaesen: Mythic Britain & Ireland_ book, and improves the talent selection user experience by supporting talents that can be taken multiple times and organizing the selection modal for clarity. The main changes are the addition of new archetypes and talents, enhancements to the talent selection UI, and logic to handle talents that can be acquired more than once.

**New Archetypes and Talents:**

* Added three new archetypes: `Athlete`, `Entertainer`, and `Socialite`.
* Added one general talent: `Performer`.

**Talent System Improvements:**

* Added a helper function `canTakeTalentMultipleTimes` to define which talents (currently `wealthy`) can be selected more than once.
* Updated the talent selection modal to:
  - Categorize talents into general and archetype-specific groups for easier browsing.
  - Allow talents that can be taken multiple times to be selected again, and indicate this in the UI.
  - Adjust the logic so that talents can be added multiple times if allowed, and display the count in the console log for clarity.